### PR TITLE
Example for Worker Node Replacement and other documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+**/examples/**/config
 
 # .tfstate files
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Local .terraform directories
 **/.terraform/*
-**/examples/**/config
+**/examples/**/**/*.pem
+**/examples/**/**/*.yml
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ This terraform module provides the following features for seamless adoption:
 ## Examples
 
 The below hyperlinks guide you to understand and demonstrate the features and capabilities of this Terraform module:
+- [IKS Cluster created using VPC Gen 2 _(Block Volumes already attached to the k8s worker nodes by the user)_](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-with-attached-drives)
 - [Installation on IKS Cluster created using VPC Gen 2 with Cloud Drives](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-with-cloud-drives)
-
+- [Worker Node Replacement on IKS Cluster created using VPC Gen 2 using Cloud Drives](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-worker-node-replace)
 ## Requirements
 
 The following are requirements needed to be installed on the host machine where the terraform commands will be issued.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,75 +1,20 @@
 # Getting Started
-This guide is intended to provide a quick start to users who want to install Portworx Enterprise on their existing IKS Clusters.
+
+This guide is intended to provide a quick start to users who want to manage Portworx Enterprise on their existing IKS Clusters using Terraform.
+
 ## Pre-requisites
+
 - Terraform >= 0.13
 - Already Provisioned IKS Cluster
 - `ibmcloud ks` cli plugin is not needed by the Terraform script but is needed to get the kubeconfig. e.g. `ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>`
 - `kubectl` installed and pointed to the correct IKS Cluster
 - `jq`, `curl`, `wget` installed on the local machine
 
-
 ## Available examples
-There are 3 examples which includes:
-- IKS Cluster created using Classic Infra **[iks-classic-infra]**
-- IKS Cluster created using VPC Gen 2 *(Block Volumes already attached to the k8s worker nodes by the user)* **[iks-with-attached-drives]**
-- IKS Cluster created using VPC Gen 2 using Cloud Drives **[iks-with-cloud-drives]**
 
-## Setting Up Environment
-In this example we'll specifically walk you through the process of installing Portworx Enterprise on IKS using Cloud Drives, the same steps can be performed for the other examples with changes to the `terraform.tfvars` file.
->Clone this Repo and `cd` into the `examples/iks-with-cloud-drives`, and now you can issue the following commands to proceed.
+There are 4 examples which includes:
 
-### Required Data/Values
-These are following data/values required that shall be passed to the terraform module as variables.
-- IKS Cluster name
-- IBM Cloud API Key
-- The Resource Group name where the Cluster exists, **the Portworx Enterprise Service Instance will be created in the same Resource Group.**
-
-### Creating Variables
-Before you run the `terraform` scripts, you can use `terraform.tfvars` or `Environment Variables` or `-var` or `-var-file` in supplement with the examples. Refer to [Terraform Documentation](https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables)
-
-We shall use `terraform.tfvars` in these examples.
-
->Example `terraform.tfvars`
->**(You can find a `terraform.tfvars.sample` file in each example directory, rename the file and set the correct values)**
-```terraform
-iks_cluster_name="your_cluster_name"
-resource_group="your_resource_group_name"
-ibmcloud_api_key="secret_ibm_cloud_key"
-```
-Create the above file with name `terraform.tfvars`
-Check the `examples/variables.tf` to understand what are the variables required
-
-## Setting up Credentials
-```sh
-export IC_API_KEY="secret_ibm_cloud_key"
-ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>
-```
-
-## Installation
-```sh
-terraform init
-terraform plan -out tf.plan
-terraform apply tf.plan
-terraform output
-```
-
-## Upgrade
-- Add the following variables to the existing `terraform.tfvars`. Replace `<newer_version>` with the version of your choice.
-```terraform
-iks_cluster_name = "your_cluster_name"
-resource_group   = "your_resource_group_name"
-ibmcloud_api_key = "secret_ibm_cloud_key"
-portworx_version = "<newer_version>"
-upgrade_portworx = true
-```
-- Plan and Apply the changes
-```sh
-terraform plan -out tf.plan
-terraform apply tf.plan
-terraform output
-```
-
-## Uninstallation
-```sh
-terraform destroy
-```
+- IKS Cluster created using Classic Infra **[iks-classic-infra](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-classic-infra)**
+- IKS Cluster created using VPC Gen 2 _(Block Volumes already attached to the k8s worker nodes by the user)_ **[iks-with-attached-drives](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-with-attached-drives)**
+- IKS Cluster created using VPC Gen 2 using Cloud Drives **[iks-with-cloud-drives](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-with-cloud-drives)**
+- Worker Node Replacement on IKS Cluster created using VPC Gen 2 using Cloud Drives **[iks-worker-node-replace](https://github.com/portworx/terraform-ibm-portworx-enterprise/tree/main/examples/iks-worker-node-replace)**

--- a/examples/iks-with-attached-drives/README.md
+++ b/examples/iks-with-attached-drives/README.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+This guide is intended to provide a quick start to users who want to install Portworx Enterprise on their existing IKS Clusters.
+
+> **NOTE:** Raw Volumes/Block Storage should be mounted on each Worker Node of the IKS Cluster before running this example.
+
+## Pre-requisites
+
+- Terraform >= 0.13
+- Already Provisioned IKS Cluster
+- `ibmcloud ks` cli plugin is not needed by the Terraform script but is needed to get the kubeconfig. e.g. `ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>`
+- `kubectl` installed and pointed to the correct IKS Cluster
+- `jq`, `curl`, `wget` installed on the local machine
+
+## Setting Up Environment
+
+In this example we'll specifically walk you through the process of installing Portworx Enterprise on IKS using Mounted Volumes, the same steps can be performed for the other examples with changes to the `terraform.tfvars` file.
+
+> Clone this Repo and `cd` into the `examples/iks-with-attached-drives`, and now you can issue the following commands to proceed.
+
+### Required Data/Values
+
+These are following data/values required that shall be passed to the terraform module as variables.
+
+- IKS Cluster name
+- IBM Cloud API Key
+- The Resource Group name where the Cluster exists, **the Portworx Enterprise Service Instance will be created in the same Resource Group.**
+
+### Creating Variables
+
+Before you run the `terraform` scripts, you can use `terraform.tfvars` or `Environment Variables` or `-var` or `-var-file` in supplement with the examples. Refer to [Terraform Documentation](https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables)
+
+We shall use `terraform.tfvars` in these examples.
+
+> Example `terraform.tfvars` **(You can find a `terraform.tfvars.sample` file in each example directory, rename the file and set the correct values)**
+
+```terraform
+iks_cluster_name="your_cluster_name"
+resource_group="your_resource_group_name"
+ibmcloud_api_key="secret_ibm_cloud_key"
+```
+
+Create the above file with name `terraform.tfvars`
+Check the `examples/variables.tf` to understand what are the variables required
+
+## Setting up Credentials
+
+```sh
+export IC_API_KEY="secret_ibm_cloud_key"
+ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>
+```
+
+## Installation
+
+```sh
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+terraform output
+```
+
+## Upgrade
+
+- Add the following variables to the existing `terraform.tfvars`. Replace `<newer_version>` with the version of your choice.
+
+```terraform
+iks_cluster_name = "your_cluster_name"
+resource_group   = "your_resource_group_name"
+ibmcloud_api_key = "secret_ibm_cloud_key"
+portworx_version = "<newer_version>"
+upgrade_portworx = true
+```
+
+- Plan and Apply the changes
+
+```sh
+terraform plan -out tf.plan
+terraform apply tf.plan
+terraform output
+```
+
+## Uninstallation
+
+```sh
+terraform destroy
+```

--- a/examples/iks-with-cloud-drives/README.md
+++ b/examples/iks-with-cloud-drives/README.md
@@ -1,0 +1,84 @@
+# Getting Started
+
+This guide is intended to provide a quick start to users who want to install Portworx Enterprise on their existing IKS Clusters.
+
+## Pre-requisites
+
+- Terraform >= 0.13
+- Already Provisioned IKS Cluster
+- `ibmcloud ks` cli plugin is not needed by the Terraform script but is needed to get the kubeconfig. e.g. `ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>`
+- `kubectl` installed and pointed to the correct IKS Cluster
+- `jq`, `curl`, `wget` installed on the local machine
+
+## Setting Up Environment
+
+In this example we'll specifically walk you through the process of installing Portworx Enterprise on IKS using Cloud Drives, the same steps can be performed for the other examples with changes to the `terraform.tfvars` file.
+
+> Clone this Repo and `cd` into the `examples/iks-with-cloud-drives`, and now you can issue the following commands to proceed.
+
+### Required Data/Values
+
+These are following data/values required that shall be passed to the terraform module as variables.
+
+- IKS Cluster name
+- IBM Cloud API Key
+- The Resource Group name where the Cluster exists, **the Portworx Enterprise Service Instance will be created in the same Resource Group.**
+
+### Creating Variables
+
+Before you run the `terraform` scripts, you can use `terraform.tfvars` or `Environment Variables` or `-var` or `-var-file` in supplement with the examples. Refer to [Terraform Documentation](https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables)
+
+We shall use `terraform.tfvars` in these examples.
+
+> Example `terraform.tfvars` **(You can find a `terraform.tfvars.sample` file in each example directory, rename the file and set the correct values)**
+
+```terraform
+iks_cluster_name="your_cluster_name"
+resource_group="your_resource_group_name"
+ibmcloud_api_key="secret_ibm_cloud_key"
+```
+
+Create the above file with name `terraform.tfvars`
+Check the `examples/variables.tf` to understand what are the variables required
+
+## Setting up Credentials
+
+```sh
+export IC_API_KEY="secret_ibm_cloud_key"
+ibmcloud ks cluster config --admin --cluster <cluster_name | cluster_id>
+```
+
+## Installation
+
+```sh
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+terraform output
+```
+
+## Upgrade
+
+- Add the following variables to the existing `terraform.tfvars`. Replace `<newer_version>` with the version of your choice.
+
+```terraform
+iks_cluster_name = "your_cluster_name"
+resource_group   = "your_resource_group_name"
+ibmcloud_api_key = "secret_ibm_cloud_key"
+portworx_version = "<newer_version>"
+upgrade_portworx = true
+```
+
+- Plan and Apply the changes
+
+```sh
+terraform plan -out tf.plan
+terraform apply tf.plan
+terraform output
+```
+
+## Uninstallation
+
+```sh
+terraform destroy
+```

--- a/examples/iks-worker-node-replace/README.md
+++ b/examples/iks-worker-node-replace/README.md
@@ -1,0 +1,63 @@
+# Getting Started
+
+This guide is intended to provide an example on how to gracefully replace a worker node with Portworx Enterprise already installed using Cloud Drives in an existing IKS VPC Gen 2 Cluster.
+You can use this example to replace all the existing worker nodes or just some of them.
+
+> **NOTE:** This example is tested on **VPC Gen2 IKS Clusters** with Portworx Enterprise provisioned with **Cloud Drives** only.
+
+## Pre-requisites
+
+- Terraform >= 0.13
+- Already Provisioned IKS Cluster with Portworx Enterprise Installed using Cloud Drives.
+
+## Setting Up Environment
+
+In this example we'll specifically walk you through the process of gracefully replacing a worker node with Portworx Enterprise already installed in an existing IKS VPC Gen 2 Cluster.
+
+> Clone this Repo and `cd` into the `examples/iks-worker-node-replace`, and now you can issue the following commands to proceed.
+
+### Required Data/Values
+
+These are following data/values required that shall be passed to the terraform scripts as variables.
+
+- IKS Cluster name
+- IBM Cloud API Key
+- The Resource Group name where the Cluster exists
+- IBM Region where Cluter is provisioned
+- List of ID's of all worker nodes which are to be replaced. **_(example ID: `kube-cd74oo9w08o0vh5e0850-superikscluster-default-000005df`)_**
+
+### Creating Variables
+
+Before you run the `terraform` scripts, you can use `terraform.tfvars` or `Environment Variables` or `-var` or `-var-file` in supplement with the examples. Refer to [Terraform Documentation](https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables)
+
+We shall use `terraform.tfvars` in these examples.
+
+> Example `terraform.tfvars` **(You can find a `terraform.tfvars.sample` file in each example directory, rename the file and set the correct values)**
+
+```terraform
+resource_group   = "your_resource_group_name"
+region           = "region_name"
+iks_cluster_name = "your_iks_cluster_name"
+worker_ids       = ["worker_id_1", "worker_id_2", "worker_id_3"]
+replace_all_workers = false
+```
+
+> NOTE: If you want to **replace all** of the existing worker nodes, toggle the value of `replace_all_workers` to `true` and remove the `worker_ids` variable
+
+Create the above file with name `terraform.tfvars`
+Check the `examples/variables.tf` to understand what are all the variables required
+
+## Setting up Credentials
+
+```sh
+export IC_API_KEY="secret_ibm_cloud_key"
+```
+
+## Replace the Worker Nodes
+
+```sh
+terraform init
+terraform plan -out tf.plan
+terraform apply tf.plan
+terraform output
+```

--- a/examples/iks-worker-node-replace/data.tf
+++ b/examples/iks-worker-node-replace/data.tf
@@ -7,6 +7,11 @@ data "ibm_container_cluster_config" "cluster" {
   cluster_name_id = data.ibm_container_vpc_cluster.cluster.id
   config_dir      = path.root
 }
+# Get all the workers from the clusters
+data "ibm_container_vpc_cluster" "cluster" {
+  name              = var.iks_cluster_name
+  resource_group_id = data.ibm_resource_group.resource_group.id
+}
 # Local variables, NOTE: Always get the list of workers into a local varibale first and then pass this local varibale to the `ibm_container_vpc_worker.resource` resource
 # DO NOT USE the `data.ibm_container_vpc_cluster.cluster.workers` variable directly in the `ibm_container_vpc_worker.worker` resource
 locals {

--- a/examples/iks-worker-node-replace/data.tf
+++ b/examples/iks-worker-node-replace/data.tf
@@ -1,0 +1,14 @@
+# Get the resource group ID for the resource group
+data "ibm_resource_group" "resource_group" {
+  name = var.resource_group
+}
+# Get the kube_config for the cluster and store in the Root Module Directory
+data "ibm_container_cluster_config" "cluster" {
+  cluster_name_id = data.ibm_container_vpc_cluster.cluster.id
+  config_dir      = path.root
+}
+# Local variables, NOTE: Always get the list of workers into a local varibale first and then pass this local varibale to the `ibm_container_vpc_worker.resource` resource
+# DO NOT USE the `data.ibm_container_vpc_cluster.cluster.workers` variable directly in the `ibm_container_vpc_worker.worker` resource
+locals {
+  workers = var.replace_all_workers ? data.ibm_container_vpc_cluster.cluster.workers : var.worker_ids
+}

--- a/examples/iks-worker-node-replace/main.tf
+++ b/examples/iks-worker-node-replace/main.tf
@@ -1,0 +1,12 @@
+# IBM Resource to replace a worker node with Portworx Enterprise Running on the Node
+
+# This resource replaces all the worker nodes in an IKS Cluster
+resource "ibm_container_vpc_worker" "workers" {
+  count             = length(local.workers)
+  cluster_name      = var.iks_cluster_name
+  replace_worker    = element(local.workers, count.index)
+  resource_group_id = data.ibm_resource_group.resource_group.id
+  kube_config_path  = data.ibm_container_cluster_config.cluster.config_file_path
+  check_ptx_status  = "true"
+  ptx_timeout       = var.timeout
+}

--- a/examples/iks-worker-node-replace/output.tf
+++ b/examples/iks-worker-node-replace/output.tf
@@ -1,0 +1,11 @@
+# Show the ID's of workers to replace
+output "workers_to_replace" {
+  value       = local.workers
+  description = "ID's of workers to replace"
+}
+
+# Show the new ID's of workers that have been replaced
+output "replaced_workers" {
+  value       = ibm_container_vpc_worker.workers.*.id
+  description = "New ID's of workers that have been replaced"
+}

--- a/examples/iks-worker-node-replace/providers.tf
+++ b/examples/iks-worker-node-replace/providers.tf
@@ -1,0 +1,3 @@
+provider "ibm" {
+  region = var.region
+}

--- a/examples/iks-worker-node-replace/terraform.tfvars.sample
+++ b/examples/iks-worker-node-replace/terraform.tfvars.sample
@@ -1,0 +1,5 @@
+resource_group   = ""
+region           = ""
+iks_cluster_name = ""
+worker_ids       = []
+replace_all_workers = false

--- a/examples/iks-worker-node-replace/variables.tf
+++ b/examples/iks-worker-node-replace/variables.tf
@@ -1,0 +1,32 @@
+variable "resource_group" {
+  type        = string
+  description = "The name of the Resource Group."
+}
+
+variable "region" {
+  type        = string
+  description = "The name of the Region."
+}
+
+variable "iks_cluster_name" {
+  type        = string
+  description = "The name of the VPC2 IKS Cluster."
+}
+
+variable "timeout" {
+  type        = string
+  description = "The wait time in minutes for Portworx Enterprise to come online after successful Node Replacement."
+  default     = "15m"
+}
+
+variable "replace_all_workers" {
+  type        = bool
+  description = "Toggle this to `false` and provide the `worker_ids` list with worker_id of each worker to be replaced."
+  default     = true
+}
+
+variable "worker_ids" {
+  type        = list(string)
+  description = "The list of `worker_ids` of the workers to be replaced."
+  default     = []
+}

--- a/examples/iks-worker-node-replace/versions.tf
+++ b/examples/iks-worker-node-replace/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=0.13"
+  required_providers {
+    ibm = {
+      source  = "IBM-Cloud/ibm"
+      version = "1.47.0-beta0"
+    }
+  }
+}


### PR DESCRIPTION
# Changes
- Added an example for Worker Node Replacement 
- Added `README.md` for Portworx Enterprise Installation on IKS with Attached Volumes
- Refactored other `README.md`

