### PR TITLE
fix: cleanup portworx resources post helm delete

### DIFF
--- a/utils/portworx_destroy.sh
+++ b/utils/portworx_destroy.sh
@@ -31,3 +31,8 @@ if [[ $? -eq 0 ]]; then
 else
     echo "[ERROR] Failed to Uninstall!!!"
 fi
+
+echo "[INFO] attempt to cleanup portworx-operator and portworx-hook clusterrole"
+kubectl delete clusterrole/portworx-hook clusterrole/portworx-operator
+echo "[INFO] attempt to cleanup portworx-operator and portworx-hook clusterrolebinding"
+kubectl delete clusterrolebinding/portworx-hook clusterrolebinding/portworx-operator


### PR DESCRIPTION
### Fix
#### What this PR does / why we need it:
The upgrade strategy uses helm upgrade with --timeout=5h0s parameters.

#### Issues
[PWX-27753](https://portworx.atlassian.net/browse/PWX-27753)

#### Solution
- update destroy script to cleanup ClusterRole and ClusterRoleBinding resources

#### Signed-off-by: 
Shivanjan Chakravorty <schakravorty@purestorage.com>
