### PR TITLE
Improving Helm management

### DIFF
--- a/utils/portworx_configure_max_storage_node_per_zone.sh
+++ b/utils/portworx_configure_max_storage_node_per_zone.sh
@@ -33,7 +33,7 @@ VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | g
 if [ "$VERSION" == "" ]; then
     printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -q
     tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version

--- a/utils/portworx_configure_max_storage_node_per_zone.sh
+++ b/utils/portworx_configure_max_storage_node_per_zone.sh
@@ -40,10 +40,10 @@ if [ "$VERSION" == "" ]; then
 fi
 
 # Get the portworx chart namespace
-CHART_NAMESPACE=$(helm ls -A | grep portworx | awk '{print $2}')
+CHART_NAMESPACE=$($CMD ls -A | grep portworx | awk '{print $2}')
 echo "[INFO] Chart namespace is $CHART_NAMESPACE"
 # Get the Helm status
-if ! JSON=$(helm history portworx -n ${CHART_NAMESPACE} -o json | jq '. | last'); then
+if ! JSON=$($CMD history portworx -n ${CHART_NAMESPACE} -o json | jq '. | last'); then
     printf "[ERROR] Helm couldn't find Portworx Installation, will not proceed with the configuration!! Please install portworx and then try to configure.\n"
     exit 1
 else

--- a/utils/portworx_configure_max_storage_node_per_zone.sh
+++ b/utils/portworx_configure_max_storage_node_per_zone.sh
@@ -27,12 +27,14 @@ export KUBECONFIG=$CONFIGPATH
 kubectl config current-context
 
 CMD="helm"
-VERSION=$($CMD version | grep v3)
+HELM_VER="v3.10.3"
+# Command is empty for v2 (--short fails) and also empty for v3 before v3.4 (where --force-update was introduced)
+VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | grep -v 'v3\.1\.' | grep -v 'v3\.2\.' | grep -v 'v3\.3\.')
 if [ "$VERSION" == "" ]; then
-    printf "[WARN] Helm v3 is not installed, migrating to v3.3.0..."
+    printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz -O /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz
-    tar -xzf /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz -C /tmp/helm3/
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version
 fi

--- a/utils/portworx_configure_max_storage_node_per_zone.sh
+++ b/utils/portworx_configure_max_storage_node_per_zone.sh
@@ -41,6 +41,7 @@ fi
 
 # Get the portworx chart namespace
 CHART_NAMESPACE=$(helm ls -A | grep portworx | awk '{print $2}')
+echo "[INFO] Chart namespace is $CHART_NAMESPACE"
 # Get the Helm status
 if ! JSON=$(helm history portworx -n ${CHART_NAMESPACE} -o json | jq '. | last'); then
     printf "[ERROR] Helm couldn't find Portworx Installation, will not proceed with the configuration!! Please install portworx and then try to configure.\n"
@@ -127,7 +128,7 @@ if [ "$ADVOPT_LINE_NO" != "" ]; then
 fi
 echo "maxStorageNodesPerZone: ${NODE_COUNT}" >> $HELM_VALUES_FILE
 printf "[INFO] maxStorageNodesPerZone value updated in ${HELM_VALUES_FILE}!!\n"
-printf "[INFO] Upgrading ${HELM_VALUES_FILE}!!\n"
+printf "[INFO] Upgrading ${HELM_VALUES_FILE} in ${CHART_NAMESPACE} namespace!!\n"
 $CMD upgrade portworx ibm-helm/portworx -f ${HELM_VALUES_FILE} -n ${CHART_NAMESPACE}
 
 if [[ $? -eq 0 ]]; then

--- a/utils/portworx_destroy.sh
+++ b/utils/portworx_destroy.sh
@@ -18,7 +18,7 @@ VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | g
 if [ "$VERSION" == "" ]; then
     printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -q
     tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version

--- a/utils/portworx_destroy.sh
+++ b/utils/portworx_destroy.sh
@@ -12,12 +12,14 @@ echo '            Uninstalling Portworx Enterprise Installation'
 echo '**********************************************************************'
 
 CMD="helm"
-VERSION=$($CMD version | grep v3)
+HELM_VER="v3.10.3"
+# Command is empty for v2 (--short fails) and also empty for v3 before v3.4 (where --force-update was introduced)
+VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | grep -v 'v3\.1\.' | grep -v 'v3\.2\.' | grep -v 'v3\.3\.')
 if [ "$VERSION" == "" ]; then
-    echo "[WARN] Helm v3 is not installed, migrating to v3.3.0..."
+    printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz -O /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz
-    tar -xzf /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz -C /tmp/helm3/
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version
 fi

--- a/utils/portworx_install_autopilot.sh
+++ b/utils/portworx_install_autopilot.sh
@@ -26,12 +26,14 @@ export KUBECONFIG=$CONFIGPATH
 kubectl config current-context
 
 CMD="helm"
-VERSION=$($CMD version | grep v3)
+HELM_VER="v3.10.3"
+# Command is empty for v2 (--short fails) and also empty for v3 before v3.4 (where --force-update was introduced)
+VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | grep -v 'v3\.1\.' | grep -v 'v3\.2\.' | grep -v 'v3\.3\.')
 if [ "$VERSION" == "" ]; then
-    printf "[WARN] Helm v3 is not installed, migrating to v3.3.0..."
+    printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz -O /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz
-    tar -xzf /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz -C /tmp/helm3/
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version
 fi

--- a/utils/portworx_install_autopilot.sh
+++ b/utils/portworx_install_autopilot.sh
@@ -37,8 +37,9 @@ if [ "$VERSION" == "" ]; then
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version
 fi
+
 # Get the Helm status
-if ! JSON=$(helm history portworx -n ${NAMESPACE} -o json | jq '. | last'); then
+if ! JSON=$($CMD history portworx -n ${NAMESPACE} -o json | jq '. | last'); then
     printf "[ERROR] Helm couldn't find Portworx Installation, will not proceed with the upgrade!! Please install portworx and then try to upgrade.\n"
     exit 1
 else

--- a/utils/portworx_install_autopilot.sh
+++ b/utils/portworx_install_autopilot.sh
@@ -32,7 +32,7 @@ VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | g
 if [ "$VERSION" == "" ]; then
     printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -q
     tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version

--- a/utils/portworx_upgrade.sh
+++ b/utils/portworx_upgrade.sh
@@ -42,7 +42,7 @@ VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | g
 if [ "$VERSION" == "" ]; then
     printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -q
     tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version

--- a/utils/portworx_upgrade.sh
+++ b/utils/portworx_upgrade.sh
@@ -36,19 +36,22 @@ export KUBECONFIG=$CONFIGPATH
 kubectl config current-context
 
 CMD="helm"
-VERSION=$($CMD version | grep v3)
+HELM_VER="v3.10.3"
+# Command is empty for v2 (--short fails) and also empty for v3 before v3.4 (where --force-update was introduced)
+VERSION=$(helm version --short 2>/dev/null | grep 'v3\.' | grep -v 'v3\.0\.' | grep -v 'v3\.1\.' | grep -v 'v3\.2\.' | grep -v 'v3\.3\.')
 if [ "$VERSION" == "" ]; then
-    echo "[WARN] Helm v3 is not installed, migrating to v3.3.0..."
+    printf "[WARN] Helm v3 is not installed, migrating to $HELM_VER..."
     mkdir /tmp/helm3
-    wget https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz -O /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz
-    tar -xzf /tmp/helm3/helm-v3.3.0-linux-amd64.tar.gz -C /tmp/helm3/
+    wget https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -O /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz
+    tar -xzf /tmp/helm3/helm-${HELM_VER}-linux-amd64.tar.gz -C /tmp/helm3/
     CMD="/tmp/helm3/linux-amd64/helm"
     $CMD version
 fi
+
 # Get the portworx chart namespace
-CHART_NAMESPACE=$(helm ls -A | grep portworx | awk '{print $2}')
+CHART_NAMESPACE=$($CMD ls -A | grep portworx | awk '{print $2}')
 # Get the Helm status
-if ! JSON=$(helm history portworx -n ${CHART_NAMESPACE} -o json | jq '. | last'); then
+if ! JSON=$($CMD history portworx -n ${CHART_NAMESPACE} -o json | jq '. | last'); then
     printf "[ERROR] Helm couldn't find Portworx Installation, will not proceed with the upgrade!! Please install portworx and then try to upgrade.\n"
     exit 1
 else


### PR DESCRIPTION
**Improvements to Helm management**:

Fixes:
- The retrieval of the Helm namespace was not leveraging the custom Helm install (`$(helm ...)` instead   
  of `$($CMD ...)`)
- The custom Helm install (v3.3) is 2 years old and does not support the `--force-update` flag introduced in v3.4

Improvements:
- The existing version check now applies to v2 & v3 versions prior to v3.4 (where `-force-update` flag was introduced)

**Special notes for your reviewer**:
I'm part of the IBM Cloud Expert Labs team in Nice, France. This will also prepare the integration with IBM Cloud 
Schematics workspaces.
