### PR TITLE
Fixed logical condition and hardcoded MaxStorage values

### DIFF
--- a/examples/iks-with-cloud-drives/variables.tf
+++ b/examples/iks-with-cloud-drives/variables.tf
@@ -84,7 +84,7 @@ variable "secret_type" {
 
 variable "max_storage_node_per_zone" {
   type        = number
-  description = "Maximum number of strorage nodes per zone"
+  description = "Maximum number of storage nodes per zone"
   default     = 1
 }
 

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "ibm_resource_instance" "portworx" {
     secret_type               = var.secret_type
     csi                       = var.portworx_csi ? "True" : "False"
     cloud_drive               = var.use_cloud_drives ? "Yes" : "No"
-    max_storage_node_per_zone = 1
+    max_storage_node_per_zone = var.cloud_drive_options.max_storage_node_per_zone
     num_cloud_drives          = var.cloud_drive_options.num_cloud_drives
     size                      = (var.cloud_drive_options.num_cloud_drives >= 1) ? element(var.cloud_drive_options.cloud_drives_sizes, 0) : 0
     size2                     = (var.cloud_drive_options.num_cloud_drives >= 2) ? element(var.cloud_drive_options.cloud_drives_sizes, 1) : 0

--- a/utils/portworx_configure_max_storage_node_per_zone.sh
+++ b/utils/portworx_configure_max_storage_node_per_zone.sh
@@ -76,7 +76,7 @@ if ! sc_state=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE}); 
     exit 1
 else
     STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o jsonpath='{.status.phase}')
-    if [ "$STATUS" != "Online" ] || [ "$STATUS" != "Running" ]; then
+    if [ "$STATUS" != "Online" ] && [ "$STATUS" != "Running" ]; then
         printf "[ERROR] Portworx Storage Cluster is not Online. Cluster Status: ($STATUS), will not proceed with configuration!!\n"
         exit 1
     else


### PR DESCRIPTION
Two main changes:-

a) max_storage nodes is hardcoded to 1? [Link](https://github.com/portworx/terraform-ibm-portworx-enterprise/blob/868d8b9b763e4a007f4115d2484fc0e327547788/main.tf#L34) 
Fixed that to make it editable

b) This condition will always be true (in case of working stc) because a value cannot be both "Online" and "Running" at the same time , leading to failure condition. [Link](https://github.com/portworx/terraform-ibm-portworx-enterprise/blob/868d8b9b763e4a007f4115d2484fc0e327547788/utils/portworx_configure_max_storage_node_per_zone.sh#L79C1)