### PR TITLE
Fix portworx status

### DIFF
--- a/utils/portworx_install_autopilot.sh
+++ b/utils/portworx_install_autopilot.sh
@@ -58,7 +58,7 @@ if ! sc_state=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE}); 
     exit 1
 else
     STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o jsonpath='{.status.phase}')
-    if [ "$STATUS" != "Online" ]; then
+    if [ "$STATUS" != "Online" || "$STATUS" != "Running"]; then
         printf "[ERROR] Portworx Storage Cluster is not Online. Cluster Status: ($STATUS), will not proceed with the upgrade!!\n"
         exit 1
     else

--- a/utils/portworx_wait_until_ready.sh
+++ b/utils/portworx_wait_until_ready.sh
@@ -10,10 +10,10 @@ RETRIES=0
 sleep 90
 
 while [ "$RETRIES" -le "$LIMIT" ]; do
-  STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep phase | cut -d ":" -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-  if [ "${STATUS// /}" == "Online" ] || [ "${STATUS// /}" == "Running" ]; then
-    CLUSTER_ID=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep clusterUid | cut -d ":" -f2)
-    printf "[SUCCESS] Portworx Storage Cluster is Online. Cluster ID: (${CLUSTER_ID// /})\n"
+  STATUS=$(kubectl get storagecluster "${PX_CLUSTER_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}' | tr -d '[:space:]')
+  if [[ "$STATUS" == "Online" || "$STATUS" == "Running" ]]; then
+    CLUSTER_ID=$(kubectl get storagecluster "${PX_CLUSTER_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.clusterUid}' | tr -d '[:space:]')
+    printf "[SUCCESS] Portworx Storage Cluster is Online. Cluster ID: (%s)\n" "$CLUSTER_ID"
     break
   fi
   printf "[INFO] Portworx Storage Cluster Status: [ $STATUS ]\n"

--- a/utils/portworx_wait_until_ready.sh
+++ b/utils/portworx_wait_until_ready.sh
@@ -10,8 +10,8 @@ RETRIES=0
 sleep 90
 
 while [ "$RETRIES" -le "$LIMIT" ]; do
-  STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep phase | cut -d ":" -f2)
-  if [[ "$STATUS" =~ ^[[:space:]]*(Online|Running)[[:space:]]*$ ]]; then
+  STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep phase | cut -d ":" -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ "${STATUS// /}" == "Online" ] || [ "${STATUS// /}" == "Running" ]; then
     CLUSTER_ID=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep clusterUid | cut -d ":" -f2)
     printf "[SUCCESS] Portworx Storage Cluster is Online. Cluster ID: (${CLUSTER_ID// /})\n"
     break

--- a/utils/portworx_wait_until_ready.sh
+++ b/utils/portworx_wait_until_ready.sh
@@ -11,7 +11,7 @@ sleep 90
 
 while [ "$RETRIES" -le "$LIMIT" ]; do
   STATUS=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep phase | cut -d ":" -f2)
-  if [ "${STATUS// /}" == "Online" ] || [ "${STATUS// /}" == "Running" ]; then
+  if [[ "$STATUS" =~ ^[[:space:]]*(Online|Running)[[:space:]]*$ ]]; then
     CLUSTER_ID=$(kubectl get storagecluster ${PX_CLUSTER_NAME} -n ${NAMESPACE} -o yaml | grep clusterUid | cut -d ":" -f2)
     printf "[SUCCESS] Portworx Storage Cluster is Online. Cluster ID: (${CLUSTER_ID// /})\n"
     break


### PR DESCRIPTION
Status check was failing due to trailing spaces for STATUS variable.
STATUS=Running
even though portworx was in running state the status check was failing because the function was returning ' Running'.

